### PR TITLE
[WIP] Routers for major endpoints 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ cdn/rooms/*
 !cdn/rooms/.gitkeep
 cdn/images/*
 !cdn/images/.gitkeep
+
+# misc
+builds/*

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.1",
     "morgan": "^1.10.0",
-    "node-fetch": "^2.6.9",
     "randomstring": "^1.3.0",
     "sequelize": "^6.28.0",
     "sqlite3": "^5.1.4",

--- a/shared-items/configv2.json
+++ b/shared-items/configv2.json
@@ -1,0 +1,281 @@
+{
+    "LevelProgressionMaps": [
+      {
+        "Level": 0,
+        "RequiredXp": 0,
+        "GiftDropId": null
+      },
+      {
+        "Level": 1,
+        "RequiredXp": 10,
+        "GiftDropId": 3288
+      },
+      {
+        "Level": 2,
+        "RequiredXp": 10,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 3,
+        "RequiredXp": 10,
+        "GiftDropId": 3288
+      },
+      {
+        "Level": 4,
+        "RequiredXp": 20,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 5,
+        "RequiredXp": 20,
+        "GiftDropId": 3288
+      },
+      {
+        "Level": 6,
+        "RequiredXp": 20,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 7,
+        "RequiredXp": 20,
+        "GiftDropId": 3288
+      },
+      {
+        "Level": 8,
+        "RequiredXp": 20,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 9,
+        "RequiredXp": 20,
+        "GiftDropId": 3288
+      },
+      {
+        "Level": 10,
+        "RequiredXp": 20,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 11,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 12,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 13,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 14,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 15,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 16,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 17,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 18,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 19,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 20,
+        "RequiredXp": 45,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 21,
+        "RequiredXp": 115,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 22,
+        "RequiredXp": 115,
+        "GiftDropId": 3292
+      },
+      {
+        "Level": 23,
+        "RequiredXp": 115,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 24,
+        "RequiredXp": 115,
+        "GiftDropId": 3292
+      },
+      {
+        "Level": 25,
+        "RequiredXp": 115,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 26,
+        "RequiredXp": 115,
+        "GiftDropId": 3292
+      },
+      {
+        "Level": 27,
+        "RequiredXp": 115,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 28,
+        "RequiredXp": 115,
+        "GiftDropId": 3292
+      },
+      {
+        "Level": 29,
+        "RequiredXp": 115,
+        "GiftDropId": 3293
+      },
+      {
+        "Level": 30,
+        "RequiredXp": 115,
+        "GiftDropId": 3292
+      }
+    ],
+    "DailyObjectives": [
+      [
+        {
+          "type": 1030,
+          "score": 1,
+          "xp": 200
+        },
+        {
+          "type": 1033,
+          "score": 10,
+          "xp": 200
+        },
+        {
+          "type": 2000,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 601,
+          "score": 2,
+          "xp": 200
+        },
+        {
+          "type": 32,
+          "score": 1,
+          "xp": 200
+        },
+        {
+          "type": 35,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 301,
+          "score": 2,
+          "xp": 200
+        },
+        {
+          "type": 302,
+          "score": 2,
+          "xp": 200
+        },
+        {
+          "type": 6,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 701,
+          "score": 2,
+          "xp": 200
+        },
+        {
+          "type": 702,
+          "score": 20,
+          "xp": 200
+        },
+        {
+          "type": 32,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 1010,
+          "score": 1,
+          "xp": 200
+        },
+        {
+          "type": 1013,
+          "score": 10,
+          "xp": 200
+        },
+        {
+          "type": 6,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 500,
+          "score": 2,
+          "xp": 200
+        },
+        {
+          "type": 502,
+          "score": 20,
+          "xp": 200
+        },
+        {
+          "type": 2000,
+          "score": 1,
+          "xp": 200
+        }
+      ],
+      [
+        {
+          "type": 1020,
+          "score": 1,
+          "xp": 200
+        },
+        {
+          "type": 1023,
+          "score": 10,
+          "xp": 200
+        },
+        {
+          "type": 32,
+          "score": 1,
+          "xp": 200
+        }
+      ]
+    ]
+}
+  

--- a/src/routes/avatar.js
+++ b/src/routes/avatar.js
@@ -1,0 +1,27 @@
+const express = require('express')
+const router = express.Router()
+const {loadAvatar, saveAvatar} = require("../avatar.js")
+const path = require("path")
+
+/* GET REQUESTS */
+router.get(`/v2`, async (req, res) => {
+    let body = await loadAvatar(req.uid)
+    res.send(body)
+})
+
+router.get(`/v3/items`, async (req, res) => {
+    res.sendFile(path.resolve(`${__dirname}/../../shared-items/avataritems.txt`))
+})
+
+router.get('/v2/gifts', (req, res) => {
+    res.send("[]")
+})
+
+/* POST REQUESTS */
+
+router.post(`/v2/set`, async (req, res) => {
+    await saveAvatar(req.uid, req.body)
+    res.send("[]")
+})
+
+module.exports = router

--- a/src/routes/avatar.js
+++ b/src/routes/avatar.js
@@ -24,4 +24,8 @@ router.post(`/v2/set`, async (req, res) => {
     res.send("[]")
 })
 
+router.get('/v2/gifts/generate', (req, res) => {
+    res.send("[]")
+})
+
 module.exports = router

--- a/src/routes/gamesessions.js
+++ b/src/routes/gamesessions.js
@@ -1,0 +1,21 @@
+const express = require('express')
+const router = express.Router()
+const {joinRandom, create} = require("../sessions.js")
+
+/* GET REQUESTS */
+router.get(`/v1/*`, async (req, res) => {
+    res.send("[]")
+})
+
+/* POST REQUESTS */
+router.post(`/v2/joinrandom`, async (req, res) => {
+    const ses = await joinRandom(req.uid, req.body)
+    res.send(ses)
+})
+
+router.post(`/v2/create`, async (req, res) => {
+    const ses = await create(req.uid, req.body)
+    res.send(ses)
+})
+
+module.exports = router

--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -1,0 +1,51 @@
+const express = require('express')
+const router = express.Router()
+const path = require("path")
+const fs = require("fs")
+const {setPFP, uploadImg, deleteImg} = require("../image.js")
+
+/* GET REQUESTS */
+router.get('/v1/profile/:id', (req, res) => {
+    try {
+        const filedir = `${__dirname}/../../cdn/profileImages/${req.params.id}.png`;
+        if (fs.existsSync(filedir)) {
+            res.sendFile(path.resolve(filedir))
+        } else {
+            res.sendStatus(404)
+        }
+    } catch(e) {
+        res.sendStatus(500)
+    }
+})
+
+router.get('/v1/named', (req, res) => {
+    if (customPosters) {
+        const filedir = `${__dirname}/../../cdn/posters/${req.query.img}.png`
+        if (fs.existsSync(filedir)) {
+            res.sendFile(path.resolve(filedir))
+        } else {
+            res.sendStatus(404)
+        }
+    } else {
+        res.sendStatus(404)
+    }
+})
+
+/* POST REQUESTS */
+
+router.post('/v*/profile', async (req, res) => {
+    await setPFP(req.uid, req)
+    res.send(JSON.stringify({ImageName: req.uid}))
+})
+
+router.post('/v*/uploadtransient', async (req, res) => {
+    const img = await uploadImg(true, req.uid, req)
+    res.send(img)
+})
+
+router.post('/v*/deletetransient', async (req, res) => {
+    await deleteImg(req)
+    res.sendStatus(200)
+})
+
+module.exports = router

--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -4,6 +4,8 @@ const path = require("path")
 const fs = require("fs")
 const {setPFP, uploadImg, deleteImg} = require("../image.js")
 
+const { customPosters } = require("../../config.json")
+
 /* GET REQUESTS */
 router.get('/v1/profile/:id', (req, res) => {
     try {

--- a/src/routes/misc.js
+++ b/src/routes/misc.js
@@ -1,6 +1,10 @@
 const express = require('express')
 const router = express.Router()
 
-//...
+/* GET REQUESTS */
+
+
+/* POST REQUESTS */
+
 
 module.exports = router

--- a/src/routes/misc.js
+++ b/src/routes/misc.js
@@ -1,0 +1,6 @@
+const express = require('express')
+const router = express.Router()
+
+//...
+
+module.exports = router

--- a/src/routes/players.js
+++ b/src/routes/players.js
@@ -1,0 +1,73 @@
+const express = require('express')
+const router = express.Router()
+const datamanager = require("../datamanager.js")
+const {getPlayerTotal, getOnlinePlayers, getPlayerArray, playerSearch} = require("../players.js")
+
+/* GET REQUESTS */
+router.get(`/v2/search`, async (req, res) => {
+    console.log(req.query)
+    let body = await playerSearch(req.query.name)
+    console.log(body)
+    res.send(JSON.stringify(body))
+})
+
+router.get(`/v1/list`, async (req, res) => {
+    res.send("[1, 11]")
+})
+
+router.get(`/v1/blockduration`, async (req, res) => {
+    res.send("[]")
+})
+
+router.get(`/v1/phonelastfour`, async (req, res) => {
+    res.send("{\"PhoneNumber\":\"PHONE NUMBERS ARE NOT SUPPORTED!\"}")
+})
+
+router.get(`/v1/search/*`, async (req, res) => {
+    res.sendStatus(404)
+})
+
+router.get(`/v1/*`, async (req, res) => {
+    let body = await datamanager.getProfile(req.uid)
+    body = JSON.parse(body)
+    res.send(JSON.stringify(body))
+})
+
+/* POST REQUESTS */
+router.post(`/v1/getorcreate`, async (req, res) => {
+    if (allow2016AndEarly2017) {
+        body = req.body.PlatformId
+        let accs = await datamanager.getAssociatedAccounts(body)
+        if (accs.length == 0) {
+            let acc = await datamanager.createAccount(`LunarRecUser_${await getPlayerTotal()+1}`, body)
+            accs = [JSON.parse(acc)]
+        }
+
+        res.send(JSON.stringify([accs[0]]))
+    } else {
+        res.sendStatus(405)
+    }
+})
+
+router.post(`/v2/phone`, async (req, res) => {
+    res.send(JSON.stringify({Success:false, Message:"Phone Numbers are not supported!"}))
+})
+
+router.post(`/v1/list`, async (req, res) => {
+    console.log(req.body)
+    let resp = await getPlayerArray(req.body)
+    console.log(resp)
+    res.send(JSON.stringify(resp))
+})
+
+router.post(`/v2/displayname`, async (req, res) => {
+    let newname = await datamanager.setName(req.uid, req.body)
+    res.send(JSON.stringify(newname))
+})
+
+router.post(`/v*/createProfile`, async (req, res) => {
+    let acc = await datamanager.createAccount(req.body.Name, req.plat)
+    res.send(acc)
+})
+
+module.exports = router

--- a/src/routes/relationships.js
+++ b/src/routes/relationships.js
@@ -1,0 +1,12 @@
+const express = require('express')
+const router = express.Router()
+
+/* GET REQUESTS */
+router.get('/v2/get', (req, res) => {
+    res.send("[]")
+})
+
+/* POST REQUESTS */
+
+
+module.exports = router

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,0 +1,16 @@
+const express = require('express')
+const router = express.Router()
+const {loadSettings, setSetting} = require("../settings.js")
+
+/* GET REQUESTS */
+router.get(`/v2`, async (req, res) => {
+    res.send(await loadSettings(req.uid))
+})
+
+/* POST REQUESTS */
+router.post(`/v2/set`, async (req, res) => {
+    setSetting(req.uid, req.body)
+    res.send("[]")
+})
+
+module.exports = router

--- a/src/server.js
+++ b/src/server.js
@@ -32,7 +32,7 @@ const authenticateToken = async (req, res, next) => {
     // Define an array of endpoints that do not require authorization
     const loginEndpoints = [
         /^\/$/,
-        /^\/img\/\d+$/,
+        /^\/img\/.+$/,
         /^\/api\/stats/,
         /^\/api\/versioncheck\//,
         /^\/api\/config\/v\d+$/,
@@ -122,6 +122,7 @@ app.get('/api/stats', async (req, res) => {
 /* ROUTES */
 app.use("/api/players", require("./routes/players.js")) // http://localhost/api/players/ requests
 app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/ requests
+app.use("/api/images", require("./routes/images.js")) // http://localhost/api/images/ requests
 
 /**
  * GET REQUESTS
@@ -213,34 +214,6 @@ app.get('/img/:id', (req, res) => {
     }
 })
 
-app.get('/api/images/v1/profile/:id', (req, res) => {
-    try {
-        const id = req.params.id
-        let filedir;
-        filedir = `${__dirname}/../cdn/profileImages/${id}.png`;
-        if (fs.existsSync(filedir)) {
-            res.sendFile(path.resolve(filedir))
-        } else {
-            res.sendStatus(404)
-        }
-    } catch(e) {
-        res.sendStatus(500)
-    }
-})
-
-app.get('/api/images/v1/named', (req, res) => {
-    if (customPosters) {
-        const filedir = `${__dirname}/../cdn/posters/${req.query.img}.png`
-        if (fs.existsSync(filedir)) {
-            res.sendFile(path.resolve(filedir))
-        } else {
-            res.sendStatus(404)
-        }
-    } else {
-        res.sendStatus(404)
-    }
-})
-
 /**
  * POST REQUESTS
  */
@@ -269,21 +242,6 @@ app.post('*/api/platformlogin/v*/', async (req, res) => {
 
     const token = jwt.sign(req.body, token_signature, {expiresIn: "12h"});
     res.send(JSON.stringify({Token: token, PlayerId:body_JWT.PlayerId, Error: ""}))
-})
-
-app.post('/api/images/v*/profile', async (req, res) => {
-    await require("./image.js").setPFP(uid, req)
-    res.send(JSON.stringify({ImageName: uid}))
-})
-
-app.post('/api/images/v*/uploadtransient', async (req, res) => {
-    var img = await require("./image.js").uploadImg(true, uid, req)
-    res.send(img)
-})
-
-app.post('/api/images/v*/deletetransient', async (req, res) => {
-    await require("./image.js").deleteImg(req)
-    res.sendStatus(200)
 })
 
 app.post(`/api/settings/v2/set`, async (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -21,9 +21,6 @@ if (logConnections) app.use(morgan(log_raw(LogType.API, `:remote-addr :method ":
 app.use(bodyParser.json()); // support json encoded bodies
 app.use(express.urlencoded({ extended: true })); // support encoded bodies
 
-// define template vars for userid and platform
-let uid = 0, plat = 0;
-
 //Authentication
 const authenticateToken = async (req, res, next) => {
     //Add lunarrec version header
@@ -60,7 +57,6 @@ const authenticateToken = async (req, res, next) => {
     //old build mode. see why it's insecure now?
     try {
         if(allow2016AndEarly2017 && Buffer.from(token).toString('base64') === "recroom@gmail.com:recnet87") {
-            uid = req.headers['x-rec-room-profile']
             req.uid = req.headers['x-rec-room-profile']
             return next();
         }
@@ -70,10 +66,6 @@ const authenticateToken = async (req, res, next) => {
       if (err) {
         return res.sendStatus(403); // Forbidden
       }
-      uid = decoded.PlayerId
-      plat = decoded.PlatformId
-
-      //Move the definitions for uid and plat into the request itself, better for when we move to routes
       req.uid = decoded.PlayerId
       req.plat = decoded.PlatformId
       next();

--- a/src/server.js
+++ b/src/server.js
@@ -75,7 +75,7 @@ const authenticateToken = async (req, res, next) => {
 
 /*
     Server code starts here.
-    TODO: Move routes to a different file
+    Smaller requests are still stored here, but most of the requests are stored in the /routes folder.
 */
 
 //Debug logging

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 //Get variables from other files
 const { targetVersion, port, serverAddress, instance_info, logConnections, customPosters, token_signature, allow2016AndEarly2017 } = require("../config.json")
 const { version } = require("../package.json")
+const { LevelProgressionMaps, DailyObjectives } = require("../shared-items/configv2.json")
 
 //Import Modules
 const express = require('express') //express.js - the web server
@@ -77,11 +78,13 @@ const authenticateToken = async (req, res, next) => {
     TODO: Move routes to a different file
 */
 
+//Debug logging
 app.use((req, res, next) => {
     log(LogType.Debug, `[${req.method.toUpperCase()} "${req.url}"] API Request: ${JSON.stringify(req.body)}`)
     next()
 })
 
+//Use authentication
 app.use(authenticateToken);
 
 //Name Server
@@ -112,12 +115,12 @@ app.get('/api/stats', async (req, res) => {
 })
 
 /* ROUTES */
-app.use("/api/players", require("./routes/players.js")) // http://localhost/api/players/ requests
-app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/ requests
-app.use("/api/images", require("./routes/images.js")) // http://localhost/api/images/ requests
-app.use("/api/settings", require("./routes/settings.js")) // http://localhost/api/settings/ requests
-app.use("/api/gamesessions", require("./routes/gamesessions.js")) // http://localhost/api/gamesessions/ requests
-app.use("/api/relationships", require("./routes/relationships.js")) // http://localhost/api/relationships/ requests
+app.use("/api/players", require("./routes/players.js")) // http://localhost/api/players/
+app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/
+app.use("/api/images", require("./routes/images.js")) // http://localhost/api/images/
+app.use("/api/settings", require("./routes/settings.js")) // http://localhost/api/settings/
+app.use("/api/gamesessions", require("./routes/gamesessions.js")) // http://localhost/api/gamesessions/
+app.use("/api/relationships", require("./routes/relationships.js")) // http://localhost/api/relationships/
 
 /**
  * GET REQUESTS
@@ -170,12 +173,12 @@ app.get('/api/config/v2', (req, res) => {
     res.send(JSON.stringify({
         MessageOfTheDay: fs.readFileSync("./shared-items/motd.txt", 'utf8'),
         CdnBaseUri: `${serverAddress}`,
-        LevelProgressionMaps:[{"Level":0,"RequiredXp":1},{"Level":1,"RequiredXp":2},{"Level":2,"RequiredXp":3},{"Level":3,"RequiredXp":4},{"Level":4,"RequiredXp":5},{"Level":5,"RequiredXp":6},{"Level":6,"RequiredXp":7},{"Level":7,"RequiredXp":8},{"Level":8,"RequiredXp":9},{"Level":9,"RequiredXp":10},{"Level":10,"RequiredXp":11},{"Level":11,"RequiredXp":12},{"Level":12,"RequiredXp":13},{"Level":13,"RequiredXp":14},{"Level":14,"RequiredXp":15},{"Level":15,"RequiredXp":16},{"Level":16,"RequiredXp":17},{"Level":17,"RequiredXp":18},{"Level":18,"RequiredXp":19},{"Level":19,"RequiredXp":20},{"Level":20,"RequiredXp":21}],
+        LevelProgressionMaps,
         MatchmakingParams:{
             PreferFullRoomsFrequency: 1,
             PreferEmptyRoomsFrequency: 0
         },
-        DailyObjectives: [[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}],[{"type":20,"score":1},{"type":21,"score":1},{"type":22,"score":1}]],
+        DailyObjectives,
         ConfigTable: [{"Key":"Gift.DropChance","Value":"0.5"},{"Key":"Gift.XP","Value":"0.5"}],
         PhotonConfig: {"CloudRegion":"us","CrcCheckEnabled":false,"EnableServerTracingAfterDisconnect":false}
     }))

--- a/src/server.js
+++ b/src/server.js
@@ -123,6 +123,7 @@ app.get('/api/stats', async (req, res) => {
 app.use("/api/players", require("./routes/players.js")) // http://localhost/api/players/ requests
 app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/ requests
 app.use("/api/images", require("./routes/images.js")) // http://localhost/api/images/ requests
+app.use("/api/settings", require("./routes/settings.js")) // http://localhost/api/settings/ requests
 
 /**
  * GET REQUESTS
@@ -154,18 +155,13 @@ app.get('/api/config/v1/amplitude', (req, res) => {
 })
 
 app.get('/api/PlayerReporting/v1/moderationBlockDetails', async (req, res) => {
-    let modstat = await datamanager.getModerationStatus(uid)
+    let modstat = await datamanager.getModerationStatus(req.uid)
     console.log(modstat)
     if (modstat.isBanned) {
         res.send(JSON.stringify({"ReportCategory":1,"Duration":600,"GameSessionId":-2000,"Message":`Moderator note: "${modstat.data.reason}".\nContact instance host to appeal`}))
     } else {
         res.send(JSON.stringify({"ReportCategory":0,"Duration":0,"GameSessionId":0,"Message":""}))
     }
-})
-
-app.get(`/api/settings/v2`, async (req, res) => {
-    let body = await require("./settings.js").loadSettings(uid)
-    res.send(body)
 })
 
 app.get('/api/equipment/v1/getUnlocked', (req, res) => {
@@ -218,10 +214,6 @@ app.get('/img/:id', (req, res) => {
  * POST REQUESTS
  */
 
-app.post(`/api/PlayerSubscriptions/v1/init`, async (req, res) => {
-    res.send("[]")
-})
-
 app.post('*/api/platformlogin/v*/profiles', async (req, res) => {
     body = req.body.PlatformId
     let accs = await datamanager.getAssociatedAccounts(body)
@@ -244,19 +236,18 @@ app.post('*/api/platformlogin/v*/', async (req, res) => {
     res.send(JSON.stringify({Token: token, PlayerId:body_JWT.PlayerId, Error: ""}))
 })
 
-app.post(`/api/settings/v2/set`, async (req, res) => {
-    await require("./settings.js").setSetting(uid, req.body)
-    res.send("[]")
-})
-
 app.post(`/api/gamesessions/v2/joinrandom`, async (req, res) => {
-    const ses = await require("./sessions.js").joinRandom(uid, req.body)
+    const ses = await require("./sessions.js").joinRandom(req.uid, req.body)
     res.send(ses)
 })
 
 app.post(`/api/gamesessions/v2/create`, async (req, res) => {
-    const ses = await require("./sessions.js").create(uid, req.body)
+    const ses = await require("./sessions.js").create(req.uid, req.body)
     res.send(ses)
+})
+
+app.post(`/api/PlayerSubscriptions/v1/init`, async (req, res) => {
+    res.send("[]")
 })
 
 const server = app.listen(port, () => {

--- a/src/server.js
+++ b/src/server.js
@@ -116,6 +116,8 @@ app.use("/api/players", require("./routes/players.js")) // http://localhost/api/
 app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/ requests
 app.use("/api/images", require("./routes/images.js")) // http://localhost/api/images/ requests
 app.use("/api/settings", require("./routes/settings.js")) // http://localhost/api/settings/ requests
+app.use("/api/gamesessions", require("./routes/gamesessions.js")) // http://localhost/api/gamesessions/ requests
+app.use("/api/relationships", require("./routes/relationships.js")) // http://localhost/api/relationships/ requests
 
 /**
  * GET REQUESTS
@@ -132,10 +134,6 @@ app.get('/api/versioncheck/*', (req, res) => {
     } else {
         res.send("{\"ValidVersion\":true}")
     }
-})
-
-app.get(`/api/gamesessions/v1/*`, async (req, res) => {
-    res.send("[]")
 })
 
 app.get(`/api/events/v*/list`, async (req, res) => {
@@ -162,10 +160,6 @@ app.get('/api/equipment/v1/getUnlocked', (req, res) => {
 
 app.get('/api/activities/charades/v1/words', (req, res) => {
     res.send(require("./charades.js").generateCharades())
-})
-
-app.get('/api/relationships/v2/get', (req, res) => {
-    res.send("[]")
 })
 
 app.get('/api/messages/v2/get', (req, res) => {
@@ -226,16 +220,6 @@ app.post('*/api/platformlogin/v*/', async (req, res) => {
 
     const token = jwt.sign(req.body, token_signature, {expiresIn: "12h"});
     res.send(JSON.stringify({Token: token, PlayerId:body_JWT.PlayerId, Error: ""}))
-})
-
-app.post(`/api/gamesessions/v2/joinrandom`, async (req, res) => {
-    const ses = await require("./sessions.js").joinRandom(req.uid, req.body)
-    res.send(ses)
-})
-
-app.post(`/api/gamesessions/v2/create`, async (req, res) => {
-    const ses = await require("./sessions.js").create(req.uid, req.body)
-    res.send(ses)
 })
 
 app.post(`/api/PlayerSubscriptions/v1/init`, async (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -121,6 +121,7 @@ app.get('/api/stats', async (req, res) => {
 
 /* ROUTES */
 app.use("/api/players", require("./routes/players.js")) // http://localhost/api/players/ requests
+app.use("/api/avatar", require("./routes/avatar.js")) // http://localhost/api/avatar/ requests
 
 /**
  * GET REQUESTS
@@ -161,15 +162,6 @@ app.get('/api/PlayerReporting/v1/moderationBlockDetails', async (req, res) => {
     }
 })
 
-app.get(`/api/avatar/v2`, async (req, res) => {
-    let body = await require("./avatar.js").loadAvatar(uid)
-    res.send(body)
-})
-
-app.get(`/api/avatar/v3/items`, async (req, res) => {
-    res.sendFile(path.resolve(`${__dirname}/../shared-items/avataritems.txt`))
-})
-
 app.get(`/api/settings/v2`, async (req, res) => {
     let body = await require("./settings.js").loadSettings(uid)
     res.send(body)
@@ -181,10 +173,6 @@ app.get('/api/equipment/v1/getUnlocked', (req, res) => {
 
 app.get('/api/activities/charades/v1/words', (req, res) => {
     res.send(require("./charades.js").generateCharades())
-})
-
-app.get('/api/avatar/v2/gifts', (req, res) => {
-    res.send("[]")
 })
 
 app.get('/api/relationships/v2/get', (req, res) => {
@@ -300,11 +288,6 @@ app.post('/api/images/v*/deletetransient', async (req, res) => {
 
 app.post(`/api/settings/v2/set`, async (req, res) => {
     await require("./settings.js").setSetting(uid, req.body)
-    res.send("[]")
-})
-
-app.post(`/api/avatar/v2/set`, async (req, res) => {
-    await require("./avatar.js").saveAvatar(uid, req.body)
     res.send("[]")
 })
 

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,4 +1,4 @@
-const fetch = require("node-fetch")
+//const fetch = require("node-fetch")
 const { webhook, serverAddress } = require("../config.json")
 
 /***


### PR DESCRIPTION
The goal of this PR is to clean up the `server.js` files routes to not be all in the same file and instead be in their own routed files.

Right now, only the following endpoints are routed:
- `api/players/*`
- `api/avatar/*`
- `api/images/*`
- `api/settings/*`
- `api/gamesessions/*`
- `api/relationships/*`

This also brings a change i've should have done a long time ago where the variables for the User ID and Platform ID are now in the request instead of changing a local variable (why didn't i do it like that to start with)